### PR TITLE
Fix early exit when processing a list of repos

### DIFF
--- a/changelog.d/70.bugfix.md
+++ b/changelog.d/70.bugfix.md
@@ -1,0 +1,1 @@
+Failing to clone a repo when looping over a list of repos does not cause the process to exit early. The process will still exit with a nonzero and the error will be logged.

--- a/src/main.zig
+++ b/src/main.zig
@@ -133,25 +133,34 @@ pub fn main(init: std.process.Init) !void {
 
     try grab.setLocation(init.io, config);
 
+    var run_failure = false;
     for (res.positionals[0]) |repo| {
         std.log.info("working on repo: {s}", .{repo});
 
         const project = grab.Project.init(repo) catch |err| switch (err) {
             error.parse => {
                 std.log.err("unable to parse: {s}", .{repo});
-                std.process.exit(1);
+                run_failure = true;
+                continue;
             },
         };
 
         std.log.debug("Project Data:\n\tSite: {s}\n\tOwner: {s}\n\tName: {s}\n\tClone: {s}", .{ project.site, project.owner, project.name, project.clone });
 
         switch (config.action) {
-            .standard => try clone(init.io, allocator, project, .{ .shallow = config.shallow }),
-            .worktree => try worktree(allocator, init.io, project, .{ .shallow = config.shallow }),
-            .remote => try addRemote(allocator, init.io, project),
+            .standard => clone(init.io, allocator, project, .{ .shallow = config.shallow }) catch {
+                run_failure = true;
+            },
+            .worktree => worktree(allocator, init.io, project, .{ .shallow = config.shallow }) catch {
+                run_failure = true;
+            },
+            .remote => addRemote(allocator, init.io, project) catch {
+                run_failure = true;
+            },
         }
     }
     std.log.info("Finished", .{});
+    if (run_failure) std.process.exit(1);
 }
 
 const gitOpts = struct { shallow: bool = false };
@@ -159,16 +168,19 @@ const gitOpts = struct { shallow: bool = false };
 fn clone(io: std.Io, allocator: std.mem.Allocator, project: grab.Project, opts: gitOpts) !void {
     var project_ = project;
     const cwd = std.Io.Dir.cwd();
-    const path = try grab.createPath(io, cwd, &[_][]const u8{ project_.site, project_.owner });
+    const path = grab.createPath(io, cwd, &[_][]const u8{ project_.site, project_.owner }) catch |err| {
+        std.log.err("unhandled error: {any}", .{err});
+        return err;
+    };
     project_.root = path;
     grab.clone(allocator, io, project_, .{ .bare = false, .shallow = opts.shallow }) catch |err| switch (err) {
         error.exists => {
             std.log.err("Unable to clone: {s}, path not empty", .{project_.name});
-            std.process.exit(1);
+            return error.clone;
         },
         else => {
             std.log.err("unhandled error: {any}", .{err});
-            std.process.exit(1);
+            return err;
         },
     };
 }
@@ -181,7 +193,10 @@ fn addRemote(allocator: std.mem.Allocator, io: std.Io, project: grab.Project) !v
         }
         paths.deinit(allocator);
     }
-    try grab.findPaths(allocator, io, &paths, project.name);
+    grab.findPaths(allocator, io, &paths, project.name) catch |err| {
+        std.log.err("unhandled error: {any}", .{err});
+        return err;
+    };
     std.log.info("Remote \"{s}\" is being added to the following projects:", .{project.owner});
     for (paths.items) |path| {
         std.log.info("\t{s}", .{path});
@@ -199,22 +214,34 @@ fn worktree(allocator: std.mem.Allocator, io: std.Io, project: grab.Project, opt
     std.log.debug("Config worktree deployment", .{});
     var project_ = project;
     const cwd = std.Io.Dir.cwd();
-    const path = try grab.createPath(io, cwd, &[_][]const u8{ project_.site, project_.owner, project_.name });
+    const path = grab.createPath(io, cwd, &[_][]const u8{ project_.site, project_.owner, project_.name }) catch |err| {
+        std.log.err("unhandled error: {any}", .{err});
+        return err;
+    };
     project_.root = path;
     grab.clone(allocator, io, project_, .{ .bare = true, .shallow = opts.shallow }) catch |err| switch (err) {
         error.exists => {
             std.log.err("Unable to clone: {s}, path not empty", .{project_.name});
-            std.process.exit(1);
+            return error.clone;
         },
         else => {
             std.log.err("unhandled error: {any}", .{err});
-            std.process.exit(1);
+            return err;
         },
     };
 
     if (project_.root) |root| {
-        try grab.linkGit(io, root);
-        try grab.setupOrigin(allocator, io, root);
-        try grab.fetchOrigin(allocator, io, root);
+        grab.linkGit(io, root) catch |err| {
+            std.log.err("unhandled error: {any}", .{err});
+            return err;
+        };
+        grab.setupOrigin(allocator, io, root) catch |err| {
+            std.log.err("unhandled error: {any}", .{err});
+            return err;
+        };
+        grab.fetchOrigin(allocator, io, root) catch |err| {
+            std.log.err("unhandled error: {any}", .{err});
+            return err;
+        };
     }
 }


### PR DESCRIPTION
Closes #70

# Summary

- Replace `std.process.exit(1)` calls inside the repo-processing loop with error returns so that a failure on one repo does not abort the rest
- Add a `run_failure` flag to track whether any repo failed during processing
- The process now continues processing remaining repos after encountering an error and exits with a nonzero code at the end if any failure occurred

# Acceptance Criteria

The issue states: *"When cloning a list of repos if one is existing the error causes the whole process to stop. This should not be the case. It should report the error but it should also continue to and process the rest of the list."*

- The `clone()`, `worktree()`, and `addRemote()` helper functions now return errors instead of calling `std.process.exit(1)`, allowing the main loop to catch failures and continue to the next repo
- Errors are logged before being returned to preserve diagnostic information for the user
- A `run_failure` flag accumulates failure state across all repos, and `std.process.exit(1)` is called only after all repos have been attempted

