### PR TITLE
Fix use-after-free in setupOrigin and fetchOrigin

### DIFF
--- a/.changes/unreleased/Fixed-20260604-205235.yaml
+++ b/.changes/unreleased/Fixed-20260604-205235.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Working path was de-allocator before use. This cause the origins not to be configured correctly. This bug was introduced during the zig 0.16.0 upgrade.
+time: 2026-06-04T20:52:35.308341822+01:00

--- a/src/root.zig
+++ b/src/root.zig
@@ -237,7 +237,7 @@ pub fn linkGit(io: std.Io, path: std.Io.Dir) !void {
 
 pub fn setupOrigin(allocator: std.mem.Allocator, io: std.Io, path: std.Io.Dir) !void {
     const _path = try path.realPathFileAlloc(io, ".", allocator);
-    allocator.free(_path);
+    defer allocator.free(_path);
     const cmd = [_][]const u8{
         "git",
         "-C",
@@ -260,7 +260,7 @@ pub fn setupOrigin(allocator: std.mem.Allocator, io: std.Io, path: std.Io.Dir) !
 
 pub fn fetchOrigin(allocator: std.mem.Allocator, io: std.Io, path: std.Io.Dir) !void {
     const _path = try path.realPathFileAlloc(io, ".", allocator);
-    allocator.free(_path);
+    defer allocator.free(_path);
     const cmd = [_][]const u8{ "git", "-C", _path, "fetch", "-p", "origin" };
     const result = std.process.run(allocator, io, .{
         .argv = &cmd,


### PR DESCRIPTION
# Summary

Fixes a bug where the working path allocated by `realPathFileAlloc` was immediately freed instead of being deferred, causing the path memory to be deallocated before it was used in the subsequent git command. This resulted in origins not being configured correctly.

The fix changes `allocator.free(_path)` to `defer allocator.free(_path)` in both `setupOrigin` and `fetchOrigin`, ensuring the path remains valid for the lifetime of the function and is properly cleaned up on exit.

This bug was introduced during the Zig 0.16.0 upgrade.
